### PR TITLE
Support tenant-specific SharePoint auth

### DIFF
--- a/src/mcp_sharepoint/common.py
+++ b/src/mcp_sharepoint/common.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from office365.sharepoint.client_context import ClientContext
 from office365.runtime.auth.client_credential import ClientCredential
+from office365.runtime.auth.authentication_context import AuthenticationContext
 
 # Configure logging
 logging.basicConfig(
@@ -31,6 +32,9 @@ if not SHP_ID_APP:
 if not SHP_ID_APP_SECRET:
     logger.error("SHP_ID_APP_SECRET environment variable not set.")
     raise ValueError("SHP_ID_APP_SECRET environment variable not set.")
+if not SHP_TENANT_ID:
+    logger.error("SHP_TENANT_ID environment variable not set.")
+    raise ValueError("SHP_TENANT_ID environment variable not set.")
 
 # Initialize MCP server
 mcp = FastMCP(
@@ -40,4 +44,7 @@ mcp = FastMCP(
 
 # Initial SharePoint context
 credentials = ClientCredential(SHP_ID_APP, SHP_ID_APP_SECRET)
-sp_context = ClientContext(SHP_SITE_URL).with_credentials(credentials)
+auth_ctx = AuthenticationContext(
+    f"https://login.microsoftonline.com/{SHP_TENANT_ID}"
+)
+sp_context = ClientContext(SHP_SITE_URL, auth_ctx).with_credentials(credentials)


### PR DESCRIPTION
## Summary
- validate presence of `SHP_TENANT_ID`
- build `AuthenticationContext` using tenant ID and apply to `ClientContext`

## Testing
- `pytest -q`
- `python - <<'PY'
import os, sys
sys.path.insert(0, 'src')
os.environ['SHP_ID_APP'] = 'foo'
os.environ['SHP_ID_APP_SECRET'] = 'bar'
os.environ['SHP_SITE_URL'] = 'https://example.sharepoint.com'
try:
    import mcp_sharepoint.common
except Exception as e:
    print(type(e).__name__, e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be7efed6cc833389320d284270079b